### PR TITLE
Enter Site Image URL from Admin panel

### DIFF
--- a/web_services/lib/site.php
+++ b/web_services/lib/site.php
@@ -24,7 +24,7 @@ function site_getinfo() {
     $siteinfo['url'] = elgg_get_site_url();
     $siteinfo['sitename'] = $site->name;
     $siteinfo['api_key'] = get_api_key();
-    $siteinfo['logo'] = get_logo();
+    $siteinfo['logo'] = elgg_get_plugin_setting('ws_get_logo', 'web_services');
     if ($site->description == null) {
         $siteinfo['description'] = '';
     } else {
@@ -34,19 +34,4 @@ function site_getinfo() {
     $siteinfo['language'] = elgg_get_config('language');
 
     return $siteinfo;
-}
-
-function get_logo($site_guid=1) {
-    global $CONFIG;
-    $query = "SELECT * from {$CONFIG->dbprefix}sites_entity"
-        . " where guid=$site_guid";
-
-    $site_data = get_data_row($query);
-
-    $return = $site_data->logo;
-
-    if ($return === null) {
-        $return ='';
-    }
-    return $return;
 }

--- a/web_services/views/default/plugins/web_services/settings.php
+++ b/web_services/views/default/plugins/web_services/settings.php
@@ -8,9 +8,17 @@ $key_view = elgg_view('input/text', array(
 	'class' => 'text_input',
 ));
 
+$logo_string = elgg_echo('Enter site logo url here. <i>(Example: http://domain.com/some/path/to/image.jpg)</i>');
+$logo_view = elgg_view('input/url', array(
+	'name' => 'params[ws_get_logo]',
+	'value' => $vars['entity']->ws_get_logo,
+	'class' => 'text_input',
+));
+
 $settings = <<<__HTML
 <div>$insert_view</div>
 <div>$key_string $key_view</div>
+<div>$logo_string $logo_view</div>
 __HTML;
 
 echo $settings;


### PR DESCRIPTION
No need to edit the database for site logo. If someone update the elgg version (1.x to 1.y) then there might be some update issue if the default database structure is tampered.
This will allow admin to add site image url from admin panel just like the google api key.
Tested in 1.12.8
